### PR TITLE
updated usage for scripts with dash args

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -31,7 +31,7 @@ There are various ways to use the profiler. The simplest is add this
 module as argument to the Python interpreter when running your
 script and add flag -v to visualize the result::
 
-    $ python -m yep -v my_script.py
+    $ python -m yep -v -- my_script.py [arg] ... ...
 
 This will create a file my_script.py.prof that can be analyzed with
 pprof. Execute ``python -m yep`` to get the full list of options.

--- a/yep.py
+++ b/yep.py
@@ -8,7 +8,7 @@ pprof for visualization.
 See http://pypi.python.org/pypi/yep for more info.
 """
 
-_CMD_USAGE = """usage: python -m yep [options] scriptfile [arg] ...
+_CMD_USAGE = """usage: python -m yep [options] -- scriptfile [arg] ...
 
 This will create a file scriptfile.prof that can be analyzed with
 pprof (google-pprof on Debian-based systems).


### PR DESCRIPTION
Module was misbehaving when profiling a script with dash style arguments; using the -- UNIX trick before the script and its args fixes the problem. Documentation updated to reflect.
